### PR TITLE
Reinstated basic phpunit script

### DIFF
--- a/includes/magento2/phpunit.inc.bash
+++ b/includes/magento2/phpunit.inc.bash
@@ -13,9 +13,9 @@ qaQuickTests="$phpUnitQuickTests" $phpCmd -f bin/phpunit \
 
 phpunitExitCode=$?
 set +x
-if (( $phpunitExitCode > 0 ))
+if (( phpunitExitCode > 0 ))
 then
-    if (( $phpunitExitCode > 2 ))
+    if (( phpunitExitCode > 2 ))
     then
         printf "\n\n\nPHPUnit Crashed\n\nRunning again with Debug mode...\n\n\n"
         qaQuickTests="$phpUnitQuickTests" phpNoXdebug -f bin/phpunit -- --debug

--- a/includes/magento2/phpunit.inc.bash
+++ b/includes/magento2/phpunit.inc.bash
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set +e
 phpCmd=phpNoXdebug
 if [[ "1" == "$phpUnitCoverage" ]]

--- a/includes/magento2/phpunit.inc.bash
+++ b/includes/magento2/phpunit.inc.bash
@@ -1,0 +1,24 @@
+set +e
+phpCmd=phpNoXdebug
+if [[ "1" == "$phpUnitCoverage" ]]
+then
+    phpCmd=\php
+fi
+
+qaQuickTests="$phpUnitQuickTests" $phpCmd -f bin/phpunit \
+    -- \
+    -c $phpUnitConfigPath
+
+phpunitExitCode=$?
+set +x
+if (( $phpunitExitCode > 0 ))
+then
+    if (( $phpunitExitCode > 2 ))
+    then
+        printf "\n\n\nPHPUnit Crashed\n\nRunning again with Debug mode...\n\n\n"
+        qaQuickTests="$phpUnitQuickTests" phpNoXdebug -f bin/phpunit -- --debug
+        set +x
+    fi
+    exit $phpunitExitCode
+fi
+set -e


### PR DESCRIPTION
Turns out the generic phpunit doesn't run against Magento 2 because it expects a $testsDir variable, and even when this is added there are other issues.

I've reinstated the basic one for now so at least it runs