### PR TITLE
Exclude DateTime from the StaticAccess rule set

### DIFF
--- a/configDefaults/generic/phpmd/ruleset.xml
+++ b/configDefaults/generic/phpmd/ruleset.xml
@@ -4,7 +4,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
          xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
-    <rule ref="rulesets/cleancode.xml"/>
+    <rule ref="rulesets/cleancode.xml">
+        <exclude name="StaticAccess" />
+    </rule>
+    <rule ref="rulesets/cleancode.xml/StaticAccess">
+        <properties>
+            <property name="exceptions" value="DateTime" />
+        </properties>
+    </rule>
     <rule ref="rulesets/codesize.xml"/>
     <rule ref="rulesets/design.xml"/>
     <rule ref="rulesets/naming.xml">


### PR DESCRIPTION
DateTime functions have to be accesses statically, so it makes sense to
prevent PHPMD throwing warning about them