### PR TITLE
Only check for the @type annotation on tests

### DIFF
--- a/src/PHPUnit/CheckAnnotations.php
+++ b/src/PHPUnit/CheckAnnotations.php
@@ -113,7 +113,12 @@ REGEXP
             return;
         }
         foreach ($matches['docblock'] as $key => $docblock) {
+            /* Found the annotation - continue */
             if (false !== strpos($docblock, '@'.$annotation)) {
+                continue;
+            }
+            /* No @test annotation found, not a test so continue */
+            if (false === strpos($docblock, '@test')) {
                 continue;
             }
             $this->errors[$fileInfo->getFilename()][] =

--- a/src/PHPUnit/CheckAnnotations.php
+++ b/src/PHPUnit/CheckAnnotations.php
@@ -101,7 +101,7 @@ class CheckAnnotations
         $matches  = [];
         preg_match_all(
             <<<REGEXP
-%(?<docblock>/\*(?:[^*]|\n|(?:\*(?:[^/]|\n)))*\*/)\s+?public\s+?function\s+?(?<method>.+?)\(%
+%(?<docblock>/\*(?:[^*]|\n|(?:\*(?:[^/]|\n)))*\*/|\n)\s+?public\s+?function\s+?(?<method>.+?)\(%
 REGEXP
             .'si',
             $contents,
@@ -112,17 +112,18 @@ REGEXP
 
             return;
         }
-        foreach ($matches['docblock'] as $key => $docblock) {
+        foreach ($matches['method'] as $key => $method) {
+            $docblock = $matches['docblock'][$key];
             /* Found the annotation - continue */
-            if (false !== strpos($docblock, '@'.$annotation)) {
+            if (false !== \strpos($docblock, '@'.$annotation)) {
                 continue;
             }
-            /* No @test annotation found, not a test so continue */
-            if (false === strpos($docblock, '@test')) {
+            /* No @test annotation found & method not beginning test =  not a test, so continue */
+            if (false === \strpos($docblock, '@test') && false === \strpos($method, 'test')) {
                 continue;
             }
             $this->errors[$fileInfo->getFilename()][] =
-                'Failed finding @'.$annotation.' for method: '.$matches['method'][$key];
+                'Failed finding @'.$annotation.' for method: '.$method;
         }
     }
 

--- a/tests/Small/PHPUnit/CheckAnnotationsTest.php
+++ b/tests/Small/PHPUnit/CheckAnnotationsTest.php
@@ -93,6 +93,7 @@ class CheckAnnotationsTest extends TestCase
         $expected             = [
             'SomethingTest.php' => [
                 'Failed finding @large for method: itDoesSomething',
+                'Failed finding @large for method: testSomethingHappens',
             ],
         ];
         $actual               = $this->checker->main($pathToTestsDirectory);

--- a/tests/assets/phpunitAnnotations/projectAllGood/tests/Large/SomethingTest.php
+++ b/tests/assets/phpunitAnnotations/projectAllGood/tests/Large/SomethingTest.php
@@ -15,4 +15,13 @@ class SomethingTest extends TestCase
     public function itDoesSomething()
     {
     }
+
+    /**
+     * @throws \Exception
+     * @covers ::somethingThings()
+     * @large
+     */
+    public function testItDoesSomething()
+    {
+    }
 }

--- a/tests/assets/phpunitAnnotations/projectAllGood/tests/Large/SomethingTest.php
+++ b/tests/assets/phpunitAnnotations/projectAllGood/tests/Large/SomethingTest.php
@@ -10,6 +10,7 @@ class SomethingTest extends TestCase
      * @throws \Exception
      * @covers ::somethingThings()
      * @large
+     * @test
      */
     public function itDoesSomething()
     {

--- a/tests/assets/phpunitAnnotations/projectAllGood/tests/Medium/SomethingTest.php
+++ b/tests/assets/phpunitAnnotations/projectAllGood/tests/Medium/SomethingTest.php
@@ -8,6 +8,7 @@ class SomethingTest extends TestCase
 {
     /**
      * @medium
+     * @test
      */
     public function itDoesSomething()
     {

--- a/tests/assets/phpunitAnnotations/projectAllGood/tests/Small/SomethingTest.php
+++ b/tests/assets/phpunitAnnotations/projectAllGood/tests/Small/SomethingTest.php
@@ -8,6 +8,7 @@ class SomethingTest extends TestCase
 {
     /**
      * @small
+     * @test
      */
     public function itDoesSomething()
     {

--- a/tests/assets/phpunitAnnotations/projectAllGood/tests/Small/SomethingTest.php
+++ b/tests/assets/phpunitAnnotations/projectAllGood/tests/Small/SomethingTest.php
@@ -13,4 +13,12 @@ class SomethingTest extends TestCase
     public function itDoesSomething()
     {
     }
+
+    /**
+     * This method does not have the size annotation but it is not a test, so this should not cause any problem
+     */
+    public function methodThatIsNotATest()
+    {
+
+    }
 }

--- a/tests/assets/phpunitAnnotations/projectMissingLarge/tests/Large/SomethingTest.php
+++ b/tests/assets/phpunitAnnotations/projectMissingLarge/tests/Large/SomethingTest.php
@@ -8,6 +8,7 @@ class SomethingTest extends TestCase
 {
     /**
      * @largo
+     * @test
      */
     public function itDoesSomething()
     {

--- a/tests/assets/phpunitAnnotations/projectMissingLarge/tests/Large/SomethingTest.php
+++ b/tests/assets/phpunitAnnotations/projectMissingLarge/tests/Large/SomethingTest.php
@@ -13,4 +13,9 @@ class SomethingTest extends TestCase
     public function itDoesSomething()
     {
     }
+
+    public function testSomethingHappens()
+    {
+
+    }
 }

--- a/tests/assets/phpunitAnnotations/projectMissingLarge/tests/Medium/SomethingTest.php
+++ b/tests/assets/phpunitAnnotations/projectMissingLarge/tests/Medium/SomethingTest.php
@@ -8,6 +8,7 @@ class SomethingTest extends TestCase
 {
     /**
      * @medium
+     * @test
      */
     public function itDoesSomething()
     {

--- a/tests/assets/phpunitAnnotations/projectMissingMedium/tests/Medium/SomethingTest.php
+++ b/tests/assets/phpunitAnnotations/projectMissingMedium/tests/Medium/SomethingTest.php
@@ -8,6 +8,7 @@ class SomethingTest extends TestCase
 {
     /**
      * @modium
+     * @test
      */
     public function itDoesSomething()
     {

--- a/tests/assets/phpunitAnnotations/projectMissingMedium/tests/Small/SomethingTest.php
+++ b/tests/assets/phpunitAnnotations/projectMissingMedium/tests/Small/SomethingTest.php
@@ -8,6 +8,7 @@ class SomethingTest extends TestCase
 {
     /**
      * @small
+     * @test
      */
     public function itDoesSomething()
     {

--- a/tests/assets/phpunitAnnotations/projectMissingSmall/tests/Medium/SomethingTest.php
+++ b/tests/assets/phpunitAnnotations/projectMissingSmall/tests/Medium/SomethingTest.php
@@ -8,6 +8,7 @@ class SomethingTest extends TestCase
 {
     /**
      * @medium
+     * @test
      */
     public function itDoesSomething()
     {

--- a/tests/assets/phpunitAnnotations/projectMissingSmall/tests/Small/SomethingTest.php
+++ b/tests/assets/phpunitAnnotations/projectMissingSmall/tests/Small/SomethingTest.php
@@ -8,6 +8,7 @@ class SomethingTest extends TestCase
 {
     /**
      * @smaalll
+     * @test
      */
     public function itDoesSomething()
     {


### PR DESCRIPTION
At the moment the Annotation check looks at all public functions with a
docblock, however at time you may want to document methods that are not
tests, for example a data provider. As these won't have the small /
medium annotations the check will fail.

This updates the check to only test docblocks that conatin @test within
them, which is the only place the annotation should appear