### PR TITLE
Before checking each method docblock check for the annotation in the …

### DIFF
--- a/tests/assets/phpunitAnnotations/projectAllGood/tests/Small/ClassDocsTest.php
+++ b/tests/assets/phpunitAnnotations/projectAllGood/tests/Small/ClassDocsTest.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace EdmondsCommerce\PHPQA\Tests\assets\phpunitAnnotations\projectAllGood\tests\Small;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class ClassDocsTest
+ *
+ * @small
+ * @package EdmondsCommerce\PHPQA\Tests\assets\phpunitAnnotations\projectAllGood\tests\Small
+ */
+class ClassDocsTest extends TestCase
+{
+
+    /**
+     * @test
+     */
+    public function testWithNoAnnotation()
+    {
+
+    }
+}


### PR DESCRIPTION
…class docblock

Certainly in PHPUnit 7.2 it is possible to set the annotation in the
class doc block and have it apply to all methods in the class. This
updates the annotation checker to see if this has been done, and if not
fall back to checking each method