### PR TITLE
run infection with no xdebug by default

### DIFF
--- a/includes/generic/infection.inc.bash
+++ b/includes/generic/infection.inc.bash
@@ -9,7 +9,7 @@ function runInfection(){
     if [[ "0" == "${phpunitFailedOnlyFiltered:-0}" ]]
     then
         # Don't run infection without xdebug
-        ${phpBinPath} -f ./bin/infection \
+         phpNoXdebug -f ./bin/infection \
             "${extraArgs[@]}" \
             --coverage=$varDir/phpunit_logs \
             --threads=${infectionThreads} \


### PR DESCRIPTION
this has fixed problems in https://github.com/edmondscommerce/mock-server and is also generally faster

The only reason to run infection with xdebug enabled is if we did not run the full suite of phpunit tests and therefore need to generate coverage