### PR TITLE
Phpqa coding standard

### DIFF
--- a/configDefaults/generic/codingStandard/ruleset.xml
+++ b/configDefaults/generic/codingStandard/ruleset.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<ruleset name="PHPQA">
+    <description>The PHPQA coding standard.</description>
+    <arg name="tab-width" value="4"/>
+
+    <!-- All of PSR12                                                         //-->
+    <!-- see vendor/squizlabs/php_codesniffer/src/Standards/PSR12/ruleset.xml //-->
+    <rule ref="PSR12"/>
+
+    <!-- no spaces when concatenating //-->
+    <rule ref="Squiz.Strings.ConcatenationSpacing">
+        <properties>
+            <property name="spacing" value="1"/>
+        </properties>
+    </rule>
+
+
+</ruleset>

--- a/configDefaults/generic/codingStandard/ruleset.xml
+++ b/configDefaults/generic/codingStandard/ruleset.xml
@@ -7,12 +7,6 @@
     <!-- see vendor/squizlabs/php_codesniffer/src/Standards/PSR12/ruleset.xml //-->
     <rule ref="PSR12"/>
 
-    <!-- no spaces when concatenating //-->
-    <rule ref="Squiz.Strings.ConcatenationSpacing">
-        <properties>
-            <property name="spacing" value="1"/>
-        </properties>
-    </rule>
 
 
 </ruleset>

--- a/includes/generic/setConfig.inc.bash
+++ b/includes/generic/setConfig.inc.bash
@@ -28,8 +28,8 @@ phpstanConfigPath="$(configPath phpstan.neon)"
 phpmdConfigPath="$(configPath phpmd/ruleset.xml)"
 
 # coding Standard for checking
-# checks for a folder called 'condingStandards' in the $projectConfigPath, falls back to the PSR2 standards
-phpcsCodingStandardsNameOrPath="PSR2"
+# For PSR2, you need to override this and set the value to "PSR2"
+phpcsCodingStandardsNameOrPath="$(configPath codingStandards)"
 
 # should coding standards warnings be a fail?
 phpcsFailOnWarning=0

--- a/includes/generic/setConfig.inc.bash
+++ b/includes/generic/setConfig.inc.bash
@@ -29,7 +29,7 @@ phpmdConfigPath="$(configPath phpmd/ruleset.xml)"
 
 # coding Standard for checking
 # For PSR2, you need to override this and set the value to "PSR2"
-phpcsCodingStandardsNameOrPath="$(configPath codingStandards)"
+phpcsCodingStandardsNameOrPath="$(configPath codingStandard)"
 
 # should coding standards warnings be a fail?
 phpcsFailOnWarning=0

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -38,14 +38,14 @@ class Helper
      */
     public static function getComposerJsonDecoded(string $path = null): array
     {
-        $path     = $path ?? self::getProjectRootDirectory().'/composer.json';
+        $path     = $path ?? self::getProjectRootDirectory() . '/composer.json';
         $contents = (string)\file_get_contents($path);
         if ('' === $contents) {
             throw new \RuntimeException('composer.json is empty');
         }
         $decoded = \json_decode($contents, true);
         if (JSON_ERROR_NONE !== \json_last_error()) {
-            throw new \RuntimeException('Failed loading composer.json: '.\json_last_error_msg());
+            throw new \RuntimeException('Failed loading composer.json: ' . \json_last_error_msg());
         }
 
         return $decoded;

--- a/src/Markdown/LinksChecker.php
+++ b/src/Markdown/LinksChecker.php
@@ -28,11 +28,11 @@ class LinksChecker
      */
     private static function getMainReadme(string $projectRootDirectory): string
     {
-        $path = $projectRootDirectory.'/README.md';
+        $path = $projectRootDirectory . '/README.md';
         if (!is_file($path)) {
             throw new \RuntimeException(
                 "\n\nYou have no README.md file in your project"
-                ."\n\nAs the bear minimum you need to have this file to pass QA"
+                . "\n\nAs the bear minimum you need to have this file to pass QA"
             );
         }
 
@@ -48,7 +48,7 @@ class LinksChecker
     private static function getDocsFiles(string $projectRootDirectory): array
     {
         $files = [];
-        $dir   = $projectRootDirectory.'/docs';
+        $dir   = $projectRootDirectory . '/docs';
         if (!is_dir($dir)) {
             return $files;
         }
@@ -120,13 +120,13 @@ class LinksChecker
         $start = \rtrim($projectRootDirectory, '/');
         if ($path[0] !== '/' || 0 === \strpos($path, './')) {
             $relativeSubdirs = \preg_replace(
-                '%^'.$projectRootDirectory.'%',
+                '%^' . $projectRootDirectory . '%',
                 '',
                 \dirname($file)
             );
-            $start           .= '/'.\rtrim($relativeSubdirs, '/');
+            $start           .= '/' . \rtrim($relativeSubdirs, '/');
         }
-        $realpath = \realpath($start.'/'.$path);
+        $realpath = \realpath($start . '/' . $path);
         if (false === $realpath) {
             $errors[] = \sprintf("\nBad link for \"%s\" to \"%s\"\n", $link[1], $link[2]);
             $return   = 1;
@@ -148,14 +148,14 @@ class LinksChecker
         $files                = static::getFiles($projectRootDirectory);
         foreach ($files as $file) {
             $relativeFile = str_replace($projectRootDirectory, '', $file);
-            $title        = "\n$relativeFile\n".str_repeat('-', strlen($relativeFile))."\n";
+            $title        = "\n$relativeFile\n" . str_repeat('-', strlen($relativeFile)) . "\n";
             $errors       = [];
             $links        = static::getLinks($file);
             foreach ($links as $link) {
                 static::checkLink($projectRootDirectory, $link, $file, $errors, $return);
             }
             if ([] !== $errors) {
-                echo $title.implode('', $errors);
+                echo $title . implode('', $errors);
             }
         }
 

--- a/src/PHPUnit/CheckAnnotations.php
+++ b/src/PHPUnit/CheckAnnotations.php
@@ -43,12 +43,12 @@ class CheckAnnotations
     {
         if (!is_dir($pathToTestsDirectory)) {
             throw new \InvalidArgumentException(
-                '$pathToTestsDirectory "'.$pathToTestsDirectory.'" does not exist"'
+                '$pathToTestsDirectory "' . $pathToTestsDirectory . '" does not exist"'
             );
         }
-        $this->largePath  = $pathToTestsDirectory.'/Large';
-        $this->mediumPath = $pathToTestsDirectory.'/Medium';
-        $this->smallPath  = $pathToTestsDirectory.'/Small';
+        $this->largePath  = $pathToTestsDirectory . '/Large';
+        $this->mediumPath = $pathToTestsDirectory . '/Medium';
+        $this->smallPath  = $pathToTestsDirectory . '/Small';
         $this->checkLarge();
         $this->checkMedium();
         $this->checkSmall();
@@ -98,7 +98,7 @@ class CheckAnnotations
     private function checkFile(\SplFileInfo $fileInfo, string $annotation): void
     {
         $contents = (string)file_get_contents($fileInfo->getPathname());
-        if($this->isAnnotationInClassDocBlock($contents, $annotation) === true) {
+        if ($this->isAnnotationInClassDocBlock($contents, $annotation) === true) {
             return;
         }
 
@@ -107,7 +107,7 @@ class CheckAnnotations
             <<<REGEXP
 %(?<docblock>/\*(?:[^*]|\n|(?:\*(?:[^/]|\n)))*\*/|\n)\s+?public\s+?function\s+?(?<method>.+?)\(%
 REGEXP
-            .'si',
+            . 'si',
             $contents,
             $matches
         );
@@ -119,7 +119,7 @@ REGEXP
         foreach ($matches['method'] as $key => $method) {
             $docblock = $matches['docblock'][$key];
             /* Found the annotation - continue */
-            if (false !== \strpos($docblock, '@'.$annotation)) {
+            if (false !== \strpos($docblock, '@' . $annotation)) {
                 continue;
             }
             /* No @test annotation found & method not beginning test =  not a test, so continue */
@@ -127,7 +127,7 @@ REGEXP
                 continue;
             }
             $this->errors[$fileInfo->getFilename()][] =
-                'Failed finding @'.$annotation.' for method: '.$method;
+                'Failed finding @' . $annotation . ' for method: ' . $method;
         }
     }
 
@@ -156,7 +156,7 @@ REGEXP
             return false;
         }
         $docBlock = array_shift($matches['docblock']);
-        return strpos($docBlock, '@'. $annotation) !== false;
+        return strpos($docBlock, '@' . $annotation) !== false;
     }
 
 

--- a/src/PHPUnit/RerunCommandGenerator.php
+++ b/src/PHPUnit/RerunCommandGenerator.php
@@ -76,7 +76,7 @@ class RerunCommandGenerator
         }
         if (null === $class || null === $name) {
             throw new \RuntimeException(
-                'Failed finding the class and/or name in the attributes:'.$attributes->__toString()
+                'Failed finding the class and/or name in the attributes:' . $attributes->__toString()
             );
         }
 
@@ -94,7 +94,7 @@ class RerunCommandGenerator
 
         $nodes = $this->simpleXml->xpath(
             '//testsuite/testcase[error] | //testsuite/testcase[failure] '
-            .'| //testsuite/testcase[skipped] | //testsuite/testcase[incomplete]'
+            . '| //testsuite/testcase[skipped] | //testsuite/testcase[incomplete]'
         );
         if (false === $nodes) {
             return [];
@@ -112,7 +112,7 @@ class RerunCommandGenerator
         if (false === $sXml) {
             $message = "Failed loading XML\n";
             foreach (libxml_get_errors() as $error) {
-                $message .= "\n\t".$error->message;
+                $message .= "\n\t" . $error->message;
             }
             throw new \RuntimeException($message);
         }
@@ -126,6 +126,6 @@ class RerunCommandGenerator
      */
     private function getDefaultFilePath(): string
     {
-        return Helper::getProjectRootDirectory().'/var/qa/phpunit.junit.log.xml';
+        return Helper::getProjectRootDirectory() . '/var/qa/phpunit.junit.log.xml';
     }
 }

--- a/src/PHPUnit/TestDox/CliTestDoxPrinter.php
+++ b/src/PHPUnit/TestDox/CliTestDoxPrinter.php
@@ -93,7 +93,6 @@ class CliTestDoxPrinter extends ResultPrinter
             $className  = $class;
             $testMethod = $test->getName();
         } else {
-
             return;
         }
 
@@ -131,8 +130,8 @@ class CliTestDoxPrinter extends ResultPrinter
     {
         if (null === $this->currentTestResult) {
             throw new \RuntimeException(
-                'Error in '.__METHOD__.': '
-                .$t->getMessage()."\n\n".$t->getTraceAsString(),
+                'Error in ' . __METHOD__ . ': '
+                . $t->getMessage() . "\n\n" . $t->getTraceAsString(),
                 $t->getCode(),
                 $t
             );
@@ -205,7 +204,7 @@ class CliTestDoxPrinter extends ResultPrinter
 
     protected function printHeader(): void
     {
-        $this->write("\n".Timer::resourceUsage()."\n\n");
+        $this->write("\n" . Timer::resourceUsage() . "\n\n");
     }
 
     private function printNonSuccessfulTestsSummary(int $numberOfExecutedTests): void

--- a/src/PHPUnit/TestDox/TestResult.php
+++ b/src/PHPUnit/TestDox/TestResult.php
@@ -74,7 +74,7 @@ final class TestResult
     ): void {
         $this->testSuccesful                = false;
         $this->symbol                       = $symbol;
-        $this->additionalInformation        .= "\n".$additionalInformation;
+        $this->additionalInformation        .= "\n" . $additionalInformation;
         $this->additionalInformationVerbose = $additionalInformationVerbose;
     }
 
@@ -94,7 +94,7 @@ final class TestResult
             ),
             $this->symbol,
             $this->testMethod,
-            $verbose ? ' '.$this->getFormattedRuntime() : '',
+            $verbose ? ' ' . $this->getFormattedRuntime() : '',
             $this->getFormattedAdditionalInformation($verbose)
         );
     }

--- a/src/Psr4Validator.php
+++ b/src/Psr4Validator.php
@@ -116,14 +116,14 @@ class Psr4Validator
             );
         }
 
-        return rtrim($namespaceRoot.$relativeNs, '\\');
+        return rtrim($namespaceRoot . $relativeNs, '\\');
     }
 
     private function getActualNamespace(\SplFileInfo $fileInfo): string
     {
         $contents = \file_get_contents($fileInfo->getPathname());
         if (false === $contents) {
-            throw new \RuntimeException('Failed getting file contents for '.$fileInfo->getPathname());
+            throw new \RuntimeException('Failed getting file contents for ' . $fileInfo->getPathname());
         }
         \preg_match('%namespace\s+?([^;]+)%', $contents, $matches);
         if ([] === $matches) {
@@ -175,12 +175,10 @@ class Psr4Validator
 
     private function addMissingPathError(string $path, string $namespaceRoot, string $absPathRoot): void
     {
-        $invalidPathMessage = "Namespace root '$namespaceRoot'".
-                              "\ncontains a path '$path''".
-                              "\nwhich doesn't exist\n";
+        $invalidPathMessage = "Namespace root '$namespaceRoot'\ncontains a path '$path'\nwhich doesn't exist\n";
         if (stripos($absPathRoot, "Magento") !== false) {
             $invalidPathMessage .= 'Magento\'s composer includes this by default, '
-                                   .'it should be removed from the psr-4 section';
+                                   . 'it should be removed from the psr-4 section';
         }
         $this->missingPaths[$path] = $invalidPathMessage;
     }
@@ -204,7 +202,7 @@ class Psr4Validator
                     $paths = [$paths];
                 }
                 foreach ($paths as $path) {
-                    $absPathRoot     = $this->pathToProjectRoot.'/'.$path;
+                    $absPathRoot     = $this->pathToProjectRoot . '/' . $path;
                     $realAbsPathRoot = \realpath($absPathRoot);
                     if (false === $realAbsPathRoot) {
                         $this->addMissingPathError($path, $namespaceRoot, $absPathRoot);

--- a/tests/Small/HelperTest.php
+++ b/tests/Small/HelperTest.php
@@ -34,7 +34,7 @@ class HelperTest extends TestCase
     public function testItWillThrowExceptionForInvalidComposerJson(): void
     {
         $this->expectException(\RuntimeException::class);
-        Helper::getComposerJsonDecoded(__DIR__.'/../assets/helper/invalid.composer.json');
+        Helper::getComposerJsonDecoded(__DIR__ . '/../assets/helper/invalid.composer.json');
     }
 
     /**
@@ -44,7 +44,7 @@ class HelperTest extends TestCase
      */
     public function testGetProjectRoot(): void
     {
-        $expected = \realpath(__DIR__.'/../../../phpqa/');
+        $expected = \realpath(__DIR__ . '/../../../phpqa/');
         $actual   = Helper::getProjectRootDirectory();
         self::assertSame($expected, $actual);
     }

--- a/tests/Small/Markdown/LinksCheckerTest.php
+++ b/tests/Small/Markdown/LinksCheckerTest.php
@@ -22,7 +22,7 @@ class LinksCheckerTest extends TestCase
      */
     public function testInvalidProject(): void
     {
-        $pathToProject    = __DIR__.'/../../assets/linksChecker/projectWithBrokenLinks';
+        $pathToProject    = __DIR__ . '/../../assets/linksChecker/projectWithBrokenLinks';
         $expectedExitCode = 1;
         $expectedOutput   = '
 /docs/linksCheckerTest.md
@@ -47,7 +47,7 @@ Bad link for "incorrect link" to "./foo.md"
     public function testMainNoReadmeFile(): void
     {
         $this->expectException(\RuntimeException::class);
-        LinksChecker::main(__DIR__.'/../../assets/linksChecker/projectNoReadme');
+        LinksChecker::main(__DIR__ . '/../../assets/linksChecker/projectNoReadme');
     }
 
     /**
@@ -57,7 +57,7 @@ Bad link for "incorrect link" to "./foo.md"
      */
     public function testValidNoDocsFolder(): void
     {
-        $pathToProject    = __DIR__.'/../../assets/linksChecker/projectWithReadmeNoDocsFolder';
+        $pathToProject    = __DIR__ . '/../../assets/linksChecker/projectWithReadmeNoDocsFolder';
         $expectedExitCode = 0;
         $expectedOutput   = '';
         self::assertResult($pathToProject, $expectedExitCode, $expectedOutput);
@@ -69,7 +69,7 @@ Bad link for "incorrect link" to "./foo.md"
      */
     public function testItHandlesNonFileLinks(): void
     {
-        $pathToProject    = __DIR__.'/../../assets/linksChecker/projectWithNonFileLinks';
+        $pathToProject    = __DIR__ . '/../../assets/linksChecker/projectWithNonFileLinks';
         $expectedExitCode = 1;
         $expectedOutput   = '
 /README.md

--- a/tests/Small/PHPUnit/CheckAnnotationsTest.php
+++ b/tests/Small/PHPUnit/CheckAnnotationsTest.php
@@ -42,7 +42,7 @@ class CheckAnnotationsTest extends TestCase
      */
     public function itReturnsNoErrorsIfItsAllGood(): void
     {
-        $pathToTestsDirectory = __DIR__.'/../../assets/phpunitAnnotations/projectAllGood/tests';
+        $pathToTestsDirectory = __DIR__ . '/../../assets/phpunitAnnotations/projectAllGood/tests';
         $expected             = [];
         $actual               = $this->checker->main($pathToTestsDirectory);
         self::assertSame($expected, $actual);
@@ -55,7 +55,7 @@ class CheckAnnotationsTest extends TestCase
      */
     public function itFindsMissingSmallAnnotations(): void
     {
-        $pathToTestsDirectory = __DIR__.'/../../assets/phpunitAnnotations/projectMissingSmall/tests';
+        $pathToTestsDirectory = __DIR__ . '/../../assets/phpunitAnnotations/projectMissingSmall/tests';
         $expected             = [
             'SomethingTest.php' => [
                 'Failed finding @small for method: itDoesSomething',
@@ -72,7 +72,7 @@ class CheckAnnotationsTest extends TestCase
      */
     public function itFindsMissingMediumAnnotations(): void
     {
-        $pathToTestsDirectory = __DIR__.'/../../assets/phpunitAnnotations/projectMissingMedium/tests';
+        $pathToTestsDirectory = __DIR__ . '/../../assets/phpunitAnnotations/projectMissingMedium/tests';
         $expected             = [
             'SomethingTest.php' => [
                 'Failed finding @medium for method: itDoesSomething',
@@ -89,7 +89,7 @@ class CheckAnnotationsTest extends TestCase
      */
     public function itFindsMissingLargeAnnotations(): void
     {
-        $pathToTestsDirectory = __DIR__.'/../../assets/phpunitAnnotations/projectMissingLarge/tests';
+        $pathToTestsDirectory = __DIR__ . '/../../assets/phpunitAnnotations/projectMissingLarge/tests';
         $expected             = [
             'SomethingTest.php' => [
                 'Failed finding @large for method: itDoesSomething',
@@ -107,7 +107,7 @@ class CheckAnnotationsTest extends TestCase
      */
     public function itReturnsNoErrorsIfNotApplicableToProject(): void
     {
-        $pathToTestsDirectory = __DIR__.'/../../assets/phpunitAnnotations/projectNotApplicable/tests';
+        $pathToTestsDirectory = __DIR__ . '/../../assets/phpunitAnnotations/projectNotApplicable/tests';
         $expected             = [];
         $actual               = $this->checker->main($pathToTestsDirectory);
         self::assertSame($expected, $actual);

--- a/tests/Small/PHPUnit/RerunCommandGeneratorTest.php
+++ b/tests/Small/PHPUnit/RerunCommandGeneratorTest.php
@@ -20,7 +20,7 @@ class RerunCommandGeneratorTest extends TestCase
     public function testCanParseFailuresAndErrors(): void
     {
         $generator = new RerunCommandGenerator();
-        $filter    = $generator->main(__DIR__.'/../../assets/phpunitRerun/phpunit.junit.log.xml');
+        $filter    = $generator->main(__DIR__ . '/../../assets/phpunitRerun/phpunit.junit.log.xml');
         self::assertNotEmpty($filter);
         self::assertNotEquals(RerunCommandGenerator::NO_FILTER, $filter);
     }
@@ -43,7 +43,7 @@ class RerunCommandGeneratorTest extends TestCase
     public function testWillReturnNoFilterIfLogIsEmpty(): void
     {
         $generator = new RerunCommandGenerator();
-        $filter    = $generator->main(__DIR__.'/../../assets/phpunitRerun/empty.phpunit.junit.log.xml');
+        $filter    = $generator->main(__DIR__ . '/../../assets/phpunitRerun/empty.phpunit.junit.log.xml');
         self::assertEquals(RerunCommandGenerator::NO_FILTER, $filter);
     }
 
@@ -54,7 +54,7 @@ class RerunCommandGeneratorTest extends TestCase
     public function testWillReturnNoFilterIfNoFailures(): void
     {
         $generator = new RerunCommandGenerator();
-        $filter    = $generator->main(__DIR__.'/../../assets/phpunitRerun/no.failures.phpunit.junit.log.xml');
+        $filter    = $generator->main(__DIR__ . '/../../assets/phpunitRerun/no.failures.phpunit.junit.log.xml');
         self::assertEquals(RerunCommandGenerator::NO_FILTER, $filter);
     }
 
@@ -66,6 +66,6 @@ class RerunCommandGeneratorTest extends TestCase
     {
         $generator = new RerunCommandGenerator();
         $this->expectException(\RuntimeException::class);
-        $generator->main(__DIR__.'/../../assets/phpunitRerun/invalid.xml.phpunit.junit.log.xml');
+        $generator->main(__DIR__ . '/../../assets/phpunitRerun/invalid.xml.phpunit.junit.log.xml');
     }
 }

--- a/tests/Small/Psr4ValidatorTest.php
+++ b/tests/Small/Psr4ValidatorTest.php
@@ -23,15 +23,15 @@ class Psr4ValidatorTest extends TestCase
      */
     public function testItFindsNoErrorsOnAValidProject(): void
     {
-        $assetsPath  = __DIR__.'/../assets/psr4/projectAllValid/';
+        $assetsPath  = __DIR__ . '/../assets/psr4/projectAllValid/';
         $projectRoot = \realpath($assetsPath);
         if (false === $projectRoot) {
-            self::fail('failed getting realpath to '.$assetsPath);
+            self::fail('failed getting realpath to ' . $assetsPath);
         }
         $validator = new Psr4Validator(
             [],
             $projectRoot,
-            Helper::getComposerJsonDecoded($projectRoot.'/composer.json')
+            Helper::getComposerJsonDecoded($projectRoot . '/composer.json')
         );
         $actual    = $validator->main();
         $expected  = [];
@@ -46,15 +46,15 @@ class Psr4ValidatorTest extends TestCase
      */
     public function testItCanHandleOddComposerConfigs(): void
     {
-        $assetsPath  = __DIR__.'/../assets/psr4/projectOddComposer/';
+        $assetsPath  = __DIR__ . '/../assets/psr4/projectOddComposer/';
         $projectRoot = \realpath($assetsPath);
         if (false === $projectRoot) {
-            self::fail('failed getting realpath to '.$assetsPath);
+            self::fail('failed getting realpath to ' . $assetsPath);
         }
         $validator = new Psr4Validator(
             [],
             $projectRoot,
-            Helper::getComposerJsonDecoded($projectRoot.'/composer.json')
+            Helper::getComposerJsonDecoded($projectRoot . '/composer.json')
         );
         $actual    = $validator->main();
         $expected  = [];
@@ -69,15 +69,15 @@ class Psr4ValidatorTest extends TestCase
      */
     public function testItFindsErrorsAndThrowsAnExceptionOnAnInvalidProject(): void
     {
-        $assetsPath  = __DIR__.'/../assets/psr4/projectInValid/';
+        $assetsPath  = __DIR__ . '/../assets/psr4/projectInValid/';
         $projectRoot = \realpath($assetsPath);
         if (false === $projectRoot) {
-            self::fail('failed getting realpath to '.$assetsPath);
+            self::fail('failed getting realpath to ' . $assetsPath);
         }
         $validator = new Psr4Validator(
             ['%IgnoredStuff%'],
             $projectRoot,
-            Helper::getComposerJsonDecoded($projectRoot.'/composer.json')
+            Helper::getComposerJsonDecoded($projectRoot . '/composer.json')
         );
         $actual    = $validator->main();
         $expected  = [
@@ -87,13 +87,13 @@ class Psr4ValidatorTest extends TestCase
                         [
                             0 =>
                                 [
-                                    'fileInfo'          => $projectRoot.'/src/Nested/Deep/Bad.php',
+                                    'fileInfo'          => $projectRoot . '/src/Nested/Deep/Bad.php',
                                     'expectedNamespace' => 'In\\Valid\\Nested\\Deep',
                                     'actualNamespace'   => 'So',
                                 ],
                             1 =>
                                 [
-                                    'fileInfo'          => $projectRoot.'/src/Wrong.php',
+                                    'fileInfo'          => $projectRoot . '/src/Wrong.php',
                                     'expectedNamespace' => 'In\\Valid',
                                     'actualNamespace'   => 'Totally',
                                 ],
@@ -101,7 +101,7 @@ class Psr4ValidatorTest extends TestCase
                 ],
             'Parse Errors:'  =>
                 [
-                    0 => $projectRoot.'/tests/ParseError.php',
+                    0 => $projectRoot . '/tests/ParseError.php',
                 ],
             'Missing Paths:' =>
                 [
@@ -116,8 +116,8 @@ Magento\'s composer includes this by default, it should be removed from the psr-
                 ],
             'Ignored Files:' =>
                 [
-                    0 => $projectRoot.'/src/IgnoredStuff/Ignored.php',
-                    1 => $projectRoot.'/src/IgnoredStuff/InvalidIgnored.php',
+                    0 => $projectRoot . '/src/IgnoredStuff/Ignored.php',
+                    1 => $projectRoot . '/src/IgnoredStuff/InvalidIgnored.php',
                 ],
         ];
 

--- a/tests/Small/Psr4ValidatorTest.php
+++ b/tests/Small/Psr4ValidatorTest.php
@@ -106,11 +106,11 @@ class Psr4ValidatorTest extends TestCase
             'Missing Paths:' =>
                 [
                     'missing/path'         => 'Namespace root \'In\\Valid\\\'
-contains a path \'missing/path\'\'
+contains a path \'missing/path\'
 which doesn\'t exist
 ',
                     'missing/magento/path' => 'Namespace root \'In\\Valid\\\'
-contains a path \'missing/magento/path\'\'
+contains a path \'missing/magento/path\'
 which doesn\'t exist
 Magento\'s composer includes this by default, it should be removed from the psr-4 section',
                 ],

--- a/tests/assets/phpunitAnnotations/projectAllGood/tests/Small/ClassDocsTest.php
+++ b/tests/assets/phpunitAnnotations/projectAllGood/tests/Small/ClassDocsTest.php
@@ -18,6 +18,5 @@ class ClassDocsTest extends TestCase
      */
     public function testWithNoAnnotation()
     {
-
     }
 }

--- a/tests/assets/phpunitAnnotations/projectAllGood/tests/Small/SomethingTest.php
+++ b/tests/assets/phpunitAnnotations/projectAllGood/tests/Small/SomethingTest.php
@@ -19,6 +19,5 @@ class SomethingTest extends TestCase
      */
     public function methodThatIsNotATest()
     {
-
     }
 }

--- a/tests/assets/phpunitAnnotations/projectMissingLarge/tests/Large/SomethingTest.php
+++ b/tests/assets/phpunitAnnotations/projectMissingLarge/tests/Large/SomethingTest.php
@@ -16,6 +16,5 @@ class SomethingTest extends TestCase
 
     public function testSomethingHappens()
     {
-
     }
 }


### PR DESCRIPTION
Now implemented a PHPQA coding standard

For now it is just PSR12, however going forwards we can extend/modify it

For projects where you want to continue with plain PSR2, you just need to override the config param or set up a codingStandard folder in your qaConfig folder